### PR TITLE
Singleton Update to simulation.py

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -21,27 +21,34 @@ from visualiser import build_fig, draw_tstep, set_style
 #np.random.seed(100)
 
 class Simulation():
+    __instance = None
     #TODO: if lockdown or otherwise stopped: destination -1 means no motion
     def __init__(self, *args, **kwargs):
-        #load default config data
-        self.Config = Configuration()
-        self.frame = 0
+        if Simulation.__instance != None:
+            raise Exception("This class is a singleton!")
+        else:
+            Simulation.__instance = self
+            #load default config data
+            self.Config = Configuration()
+            self.frame = 0
 
-        #initialize default population
-        self.population_init()
+            #initialize default population
+            self.population_init()
 
-        self.pop_tracker = Population_trackers()
+            self.pop_tracker = Population_trackers()
 
-        #initalise destinations vector
-        self.destinations = initialize_destination_matrix(self.Config.pop_size, 1)
+            #initalise destinations vector
+            self.destinations = initialize_destination_matrix(self.Config.pop_size, 1)
 
-        self.fig, self.spec, self.ax1, self.ax2 = build_fig(self.Config)
+            self.fig, self.spec, self.ax1, self.ax2 = build_fig(self.Config)
 
-        #set_style(self.Config)
+            #set_style(self.Config)
 
 
     def population_init(self):
         '''(re-)initializes population'''
+        if Simulation.__instance == None:
+            Simulation()
         self.population = initialize_population(self.Config, self.Config.mean_age, 
                                                 self.Config.max_age, self.Config.xbounds, 
                                                 self.Config.ybounds)
@@ -157,7 +164,8 @@ dead: %i, of total: %i' %(self.frame, self.pop_tracker.susceptible[-1], self.pop
 
     def run(self):
         '''run simulation'''
-
+        if Simulation.__instance == None:
+            Simulation()
         i = 0
         
         while i < self.Config.simulation_steps:

--- a/simulation.py
+++ b/simulation.py
@@ -25,7 +25,7 @@ class Simulation():
     #TODO: if lockdown or otherwise stopped: destination -1 means no motion
     def __init__(self, *args, **kwargs):
         if Simulation.__instance != None:
-            raise Exception("This class is a singleton!")
+            raise Exception("This class is a singleton!, only 1 instance is allowed")
         else:
             Simulation.__instance = self
             #load default config data


### PR DESCRIPTION
**Proposed Changes**
Updated simulation.py to be be a Singleton, as only 1 instance of the simulation should exist.

**Why I did it (Design Decision)**
In this PR I applied the singleton creation pattern to the SUD. I was exploring the code and I found that the code was not designed to have more than one instance of simulation.py going on at the same time. Any attempt to do so will cause the other instances to display a window but not run. Therefore it seemed apt to make this into a singleton as then only 1 instance is allowed ever. I made the program throw an exception if one changes the code to try to run more than one instance. In addition I wanted global access to this as any changes that needed to be made should be with this class if it was ever expanded to be part of a larger program, like the goals of abstraction. 

The advantages of this is it limits the program from creating more useless instances that do nothing.  I will be sure that class has only a single instance and there is a global access point to that instance.

The disadvantage is if for some reason in the future Paul reworks the program to do multiple instances then this would have to be rolled back.

**What I did (How I applied the design)**
To apply the singleton pattern, I created a variable called __instance. Python does not have private variables but there is a standard convention, which is to have __ before the variable name, which shows to other developers that it should be treated as a private variable. This variable will hold our only instance of this class. I then checked on creation of the class, if there was something there or not. If there is, it will not create the class and warns the user, if there isn't the program progresses normally.

**Checklist**
- [x] Tests
- [ ] Translations
- [ ] Documentation

